### PR TITLE
feat: add image popup viewer and fix elm initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ tags
 
 # other
 .DS_Store
+
+/node_modules

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ My website:
 
 Common instructions to develop this website:
 
+- `./rerender.sh`: generate all HTML files from Markdown
 - `elm-watch make hot`: build website with hot reloading
+- `elm-watch hot "dev"`: run website with hot reloading
 - `elm-watch make --optimize`: build website for production release
 - `elm-format src/ --yes`: format all files inside the `src/` directory
 - `explorer.exe index.html`: open the file in the browser for viewing
@@ -16,3 +18,5 @@ Common instructions to develop this website:
   - **Install:** `elm install elm/time`
   - **Uninstall:** `elm-json uninstall elm/time`
     - _Requires:_ `npm install --global elm-json`
+
+You also need to install `pandoc` to build the website.

--- a/css/article.css
+++ b/css/article.css
@@ -207,3 +207,35 @@ details[open] > summary::before {
     margin-right: 0.5em;
     transform: rotate(90deg);
 }
+
+/* Image popup styles */
+.popup-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.9);
+    z-index: 1000;
+    cursor: pointer;
+}
+
+.popup-image {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    max-width: 90%;
+    max-height: 90vh;
+    z-index: 1001;
+}
+
+img:not(.popup-image) {
+    cursor: pointer;
+    transition: opacity 0.3s ease;
+}
+
+img:not(.popup-image):hover {
+    opacity: 0.8;
+}

--- a/elm-watch.json
+++ b/elm-watch.json
@@ -1,6 +1,6 @@
 {
     "targets": {
-        "My target name": {
+        "dev": {
             "inputs": [
                 "src/Main.elm"
             ],

--- a/index.html
+++ b/index.html
@@ -1,46 +1,74 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <title>Dmitrii Kovanikov aka chshersh</title>
-    <meta name="description" content="Personal website and blog">
-    <meta name="author" content="Dmitrii Kovanikov">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <link rel="stylesheet" href="/css/styles.css">
+	<title>Dmitrii Kovanikov aka chshersh</title>
+	<meta name="description" content="Personal website and blog">
+	<meta name="author" content="Dmitrii Kovanikov">
 
-    <!-- Metatags -->
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Dmitrii Kovanikov aka chshersh" />
-    <meta property="og:title" content="Dmitrii Kovanikov aka chshersh" />
-    <meta property="og:description" content="About, my blog" />
-    <meta property="og:url" content="https://chshersh.com" />
-    <meta property="og:image" content="/images/logo.jpg" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Dmitrii Kovanikov aka chshersh" />
-    <meta name="twitter:description" content="$description$" />
-    <meta name="twitter:image:src" content="https://chshersh.com/images/logo.jpg" />
-    <meta name="twitter:url" content="https://chshersh.com" />
+	<link rel="stylesheet" href="/css/styles.css">
 
-    <!-- Favicon -->
-    <link rel="icon" href="/favicon.ico" type="image/x-icon">
-    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
-  </head>
-  <body>
-    <div id="root"></div>
-    <script src="./build/main.min.js"></script>
-    <script>
-      var app = Elm.Main.init({
-        node: document.getElementById("root"),
-        flags: {
-          height: window.innerHeight,
-          width: window.innerWidth
-        }
-      });
+	<!-- Metatags -->
+	<meta property="og:type" content="website" />
+	<meta property="og:site_name" content="Dmitrii Kovanikov aka chshersh" />
+	<meta property="og:title" content="Dmitrii Kovanikov aka chshersh" />
+	<meta property="og:description" content="About, my blog" />
+	<meta property="og:url" content="https://chshersh.com" />
+	<meta property="og:image" content="/images/logo.jpg" />
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:title" content="Dmitrii Kovanikov aka chshersh" />
+	<meta name="twitter:description" content="$description$" />
+	<meta name="twitter:image:src" content="https://chshersh.com/images/logo.jpg" />
+	<meta name="twitter:url" content="https://chshersh.com" />
 
-      app.ports.newTab.subscribe( url => window.open(url, '_blank'));
-    </script>
-  </body>
+	<!-- Favicon -->
+	<link rel="icon" href="/favicon.ico" type="image/x-icon">
+	<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
+	<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
+</head>
+
+<body>
+	<div id="root"></div>
+	<script src="./build/main.min.js"></script>
+	<script>
+		document.addEventListener('DOMContentLoaded', function () {
+			setTimeout(function () {
+				var app = Elm.Main.init({
+					node: document.getElementById("root"),
+					flags: {
+						height: window.innerHeight,
+						width: window.innerWidth
+					}
+				});
+
+				app.ports.newTab.subscribe(function (url) {
+					window.open(url, '_blank');
+				});
+			}, 0);
+		});
+
+		window.addEventListener('resize', function () {
+			if (app) {
+				app.ports.windowResize.send({
+					width: window.innerHeight,
+					height: window.innerWidth
+				});
+			}
+		});
+
+		var app = Elm.Main.init({
+			node: document.getElementById("root"),
+			flags: {
+				height: window.innerHeight,
+				width: window.innerWidth
+			}
+		});
+
+		app.ports.newTab.subscribe(url => window.open(url, '_blank'));
+	</script>
+</body>
+
 </html>

--- a/templates/article.html
+++ b/templates/article.html
@@ -30,6 +30,10 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
 </head>
 <body>
+    <div id="imagePopup" class="popup-overlay">
+        <img class="popup-image" id="popupImg" src="" alt="">
+    </div>
+
     <header>
       <h1>$title$</h1>
     </header>
@@ -54,5 +58,33 @@ $body$
 </ul>
 </blockquote>
     </main>
+
+    <script>
+        const popup = document.getElementById('imagePopup');
+        const popupImg = document.getElementById('popupImg');
+
+        document.querySelectorAll('main img:not(.popup-image)').forEach(img => {
+            img.addEventListener('click', function() {
+                popup.style.display = 'block';
+                popupImg.src = this.src;
+                document.body.style.overflow = 'hidden';
+            });
+        });
+
+
+        popup.addEventListener('click', function(e) {
+            if (e.target === popup) {
+                popup.style.display = 'none';
+                document.body.style.overflow = ''; 
+            }
+        });
+
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape' && popup.style.display === 'block') {
+                popup.style.display = 'none';
+                document.body.style.overflow = ''; 
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Hey Dmitrii! I don't know if you will accept this pull request since it is a feature that adds some new codes... But if not, it's ok! But it would be nice to have some way to expand the images in your posts!

Hope you like it!

- Add image popup functionality to blog articles with click-to-zoom
- Fix Elm app initialization with proper DOM loading
- Update elm-watch target name from "My target name" to "dev"
- Add node_modules to gitignore
- Update README with pandoc requirement and new commands

The image popup viewer allows users to:
- Click any image to view it in a larger overlay
- Close by clicking outside or pressing ESC



https://github.com/user-attachments/assets/78bdfc1a-9a37-4fba-a1c1-8a334acb54c9